### PR TITLE
Fix DISABLE_SSH env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM phusion/baseimage:0.10.0
+FROM sgarzarella/baseimage-phusion-armhf:0.10.0
 
-LABEL maintainer="dlandon"
+MAINTAINER Stefano <stefano.garzarella@gmail.com>
 
 ENV	DEBCONF_NONINTERACTIVE_SEEN="true" \
 	DEBIAN_FRONTEND="noninteractive" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="dlandon"
 
 ENV	DEBCONF_NONINTERACTIVE_SEEN="true" \
 	DEBIAN_FRONTEND="noninteractive" \
-	DISABLESSH="true" \
+	DISABLE_SSH="true" \
 	HOME="/root" \
 	LC_ALL="C.UTF-8" \
 	LANG="en_US.UTF-8" \


### PR DESCRIPTION
The correct variable in phusion/baseimage-docker to set to disable SSH is DISABLE_SSH.